### PR TITLE
Remove t2-kernel-script-debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,30 +11,6 @@ set of debian packages.
 
 ## Installation
 
-### Using the kernel upgrade script
-
-Firstly add the **t2-ubuntu-repo** apt repo
-
-```bash
-curl -s --compressed "https://adityagarg8.github.io/t2-ubuntu-repo/KEY.gpg" | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/t2-ubuntu-repo.gpg >/dev/null
-sudo curl -s --compressed -o /etc/apt/sources.list.d/t2.list "https://adityagarg8.github.io/t2-ubuntu-repo/t2.list"
-sudo apt update
-```
-
-Install the script by running:
-
-```bash
-sudo apt install t2-kernel-script-debian
-```
-
-Whenever you wish to upgrade your kernel, run:
-
-```bash
-update_t2_kernel
-```
-
-**Note :-** By default, whenever you run `update_t2_kernel`, the script installs the latest kernel as well as preserves the kernel which is booted during running of the script. Rest all old t2 kernels get removed (self compiled and official Debian kernels are not affected). In case you wish to remove the kernel which is booted as well, run `update_t2_kernel --remove-current`.
-
 ### Download package manually
 
 Download the .deb packages of **linux-headers** and **linux-image** of


### PR DESCRIPTION
Hi @andersfugmann 

I no longer host the kernel upgrade script on my repo since I added Debian support on the Main repo. But people who still use your kernels often contact about this. So this PR removes the instructions.